### PR TITLE
move tracepoint tracing to dedicate singleton module

### DIFF
--- a/lib/hermes.rb
+++ b/lib/hermes.rb
@@ -5,7 +5,7 @@ require 'hermes/version'
 
 module Hermes
   class << self
-    attr_accessor :configuration
+    attr_accessor :configuration, :pastel
   end
 
   def self.configuration
@@ -14,6 +14,10 @@ module Hermes
 
   def self.reset
     @configuration = Configuration.new
+  end
+
+  def self.pastel
+    @pastel ||= Pastel.new(enabled: true)
   end
 
   def self.configure

--- a/lib/hermes/rspec.rb
+++ b/lib/hermes/rspec.rb
@@ -2,58 +2,31 @@
 #
 # frozen_string_literal: true
 
-# rubocop:disable Style/GlobalVars
-
 require 'pastel'
 require 'json'
 require 'pry'
+require 'hermes/tracers/tracepoint'
 
 RSpec.configure do |config|
   next unless Hermes.configuration.rspec_enabled?
 
-  # NOTE: we use a global var as its the only way
-  # to ensure the var persists across scenarios.
-  # This allows us to limit the number of file writes
-  # which drastically improves performance
-  $rspec_tracepoint_report = {}
-  $rspec_rails_root = "#{Rails.root}/"
-
-  RSPEC_TRACEPOINT_REPORT = "#{$rspec_rails_root}/knapsack_rspec_tracepoint_report.json"
-
-  pastel = Pastel.new(enabled: true)
-
+  pastel = Hermes.pastel
   puts pastel.bold.blue('[HERMES] rspec tracing enabled').to_s
 
-  tracepoint_scope = Hermes.configuration.tracepoint_scope
+  RSPEC_TRACEPOINT_REPORT = "#{Rails.root}/knapsack_rspec_tracepoint_report.json"
+
   config.around do |example|
-    traces = {}
-
-    tracer = TracePoint.new(*tracepoint_scope) do |tp|
-      path = tp.path
-
-      # NOTE: only log paths in our rails app
-      # ignore gem paths like:
-      # ~/.rbenv/versions/2.6.7/lib/ruby/gems/2.6.0/gems/activerecord-6.0.3.4/lib/active_record/model_schema.rb
-      next false unless path.starts_with?($rspec_rails_root)
-
-      # NOTE: we mimic the behavior of a Set but use a lightweight hash instead
-      traces[path] = true
-    end
-
-    tracer.enable { example.run }
-
-    $rspec_tracepoint_report[example.example.id] = traces.keys
+    Hermes::Tracers::Tracepoint.enable { example.run }
   end
 
   # NOTE: this occurs after a knapsack node finishes executing
   # write the $rspec_tracepoint_report to disk
   at_exit do
     file = File.open(RSPEC_TRACEPOINT_REPORT, 'w')
-    file.puts $rspec_tracepoint_report.to_json
+    file.puts Hermes::Tracers::Tracepoint.report.to_json
     file.close
 
-    puts pastel.bold.blue('[HERMES] tracepoint report generated').to_s
+    puts pastel.bold.green('[HERMES] tracepoint report generated').to_s
+    Hermes::Tracers::Tracepoint.reset
   end
 end
-
-# rubocop:enable Style/GlobalVars

--- a/lib/hermes/rspec.rb
+++ b/lib/hermes/rspec.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
   RSPEC_TRACEPOINT_REPORT = "#{Rails.root}/knapsack_rspec_tracepoint_report.json"
 
   config.around do |example|
-    Hermes::Tracers::Tracepoint.enable { example.run }
+    Hermes::Tracers::Tracepoint.enable(test_id: example.example.id) { example.run }
   end
 
   # NOTE: this occurs after a knapsack node finishes executing

--- a/lib/hermes/tracers/tracepoint.rb
+++ b/lib/hermes/tracers/tracepoint.rb
@@ -1,0 +1,57 @@
+# Copyright 2021 HackerOne Inc.
+#
+# frozen_string_literal: true
+require 'pastel'
+require 'json'
+require 'pry'
+
+module Hermes
+  module Tracers
+    module Tracepoint
+      class << self
+        attr_accessor :report, :tracer, :buffer
+      end
+
+      def self.report
+        @report ||= {}
+      end
+
+      def self.buffer
+        @buffer ||= {}
+      end
+
+      def self.tracer
+        @tracer ||= begin
+          tracepoint_scope = Hermes.configuration.tracepoint_scope
+          rspec_rails_root = "#{Rails.root}/"
+
+          TracePoint.new(*tracepoint_scope) do |tp|
+            path = tp.path
+
+            # NOTE: only log paths in our rails app
+            # ignore gem paths like:
+            # ~/.rbenv/versions/2.6.7/lib/ruby/gems/2.6.0/gems/activerecord-6.0.3.4/...
+            next false unless path.starts_with?(rspec_rails_root)
+
+            # NOTE: we mimic the behavior of a Set but use a lightweight hash instead
+            buffer[path] = true
+          end
+        end
+      end
+
+      def self.reset
+        @report = {}
+        @buffer = {}
+        @tracer = nil
+      end
+
+      def self.enable(test_id:)
+        @buffer = {}
+
+        tracer.enable { yield }
+
+        report[test_id] = traces.keys
+      end
+    end
+  end
+end

--- a/lib/hermes/tracers/tracepoint.rb
+++ b/lib/hermes/tracers/tracepoint.rb
@@ -50,7 +50,7 @@ module Hermes
 
         tracer.enable { yield }
 
-        report[test_id] = traces.keys
+        report[test_id] = buffer.keys
       end
     end
   end


### PR DESCRIPTION
This PR moves the tracepoint tracing logic to a dedicated singleton module.

The benefit of doing so is:
1. Hermes no longer needs global variables in its rspec lib file, as the singleton ensures the tracepoint report is not reset in between specs.
2. Hermes will be able to share the tracepoint tracer logic and other tracers that will be introduced, across different test suites. (integration, acceptance).
3. Performance enhancements to tracepoint tracing can be made in a single module and will benefit all test suites.

Verified both locally and on CI that `knapsack_test_source_file` is still generated correctly.

![image](https://user-images.githubusercontent.com/1220084/129275365-58c11ad1-4fcb-43a7-938d-4cf9b876d92c.png)

GL mr id: 9550